### PR TITLE
Fix Linux shutdown race

### DIFF
--- a/RuneHelper/core/RuneHelperApp.cpp
+++ b/RuneHelper/core/RuneHelperApp.cpp
@@ -434,6 +434,12 @@ void RuneHelperApp::RequestOcrRebuild()
 void RuneHelperApp::Shutdown()
 {
     running_ = false;
+    if (initThread_.joinable())
+        initThread_.join();
+
+    if (ocrThread_.joinable())
+        ocrThread_.join();
+
     ui_.UnregisterHotkeys();
 #ifdef _WIN32
     screenCapture_.Shutdown();


### PR DESCRIPTION
This PR fixes a race condition during application shutdown on Linux.

The OCR worker thread could still be processing data while RuneHelperApp was being destroyed, resulting in intermittent crashes on exit (double free or corruption, std::bad_alloc, or other undefined behaviour depending on timing).

The fix explicitly joins the worker threads during Shutdown() before any dependent objects begin destruction, ensuring the background workers have exited cleanly before teardown continues.
